### PR TITLE
Update for Stardew Valley 1.2

### DIFF
--- a/FarmAutomation.Common/GhostFarmer.cs
+++ b/FarmAutomation.Common/GhostFarmer.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using StardewValley;
+using SFarmer = StardewValley.Farmer;
 
 namespace FarmAutomation.Common
 {
     /// <summary>
     /// helper class for actions where a reference to a farmer is necessary
     /// </summary>
-    public class GhostFarmer : Farmer
+    public class GhostFarmer : SFarmer
     {
         private GhostFarmer() : base(new FarmerSprite(null), Vector2.Zero, 1, "GhostFarmer", new List<Item>(), true)
         {

--- a/FarmAutomation.ItemCollector/ItemCollectorMod.cs
+++ b/FarmAutomation.ItemCollector/ItemCollectorMod.cs
@@ -120,11 +120,6 @@ namespace FarmAutomation.ItemCollector
 
         private static List<AcceptableObject> _GetSeedMakerMaterials()
         {
-            if (Game1.temporaryContent == null)
-            {
-                Game1.temporaryContent = new LocalizedContentManager(Game1.content.ServiceProvider, Game1.content.RootDirectory);
-            }
-
             return (from v in Game1.temporaryContent.Load<Dictionary<int, string>>(@"Data\Crops").Values
                     select v.Split('/') into s
                     select new AcceptableObject(Convert.ToInt32(s[3]))).ToList();

--- a/FarmAutomation.ItemCollector/Processors/MachineHelper.cs
+++ b/FarmAutomation.ItemCollector/Processors/MachineHelper.cs
@@ -6,6 +6,7 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Objects;
 using Object = StardewValley.Object;
+using SFarmer = StardewValley.Farmer;
 
 namespace FarmAutomation.ItemCollector.Processors
 {
@@ -148,7 +149,7 @@ namespace FarmAutomation.ItemCollector.Processors
             }
         }
 
-        public static Object MoveItemToFarmer(Object itemToMove, Chest sourceChest, Farmer target, int amount)
+        public static Object MoveItemToFarmer(Object itemToMove, Chest sourceChest, SFarmer target, int amount)
         {
             var temporaryItem = (Object)itemToMove.getOne();
             temporaryItem.Stack = amount;
@@ -199,7 +200,7 @@ namespace FarmAutomation.ItemCollector.Processors
             return !(machine is Chest) && machine.minutesUntilReady == 0 && machine.heldObject == null;
         }
 
-        public static bool PutItemInMachine(Object machine, Object refillable, Farmer who)
+        public static bool PutItemInMachine(Object machine, Object refillable, SFarmer who)
         {
             return machine.performObjectDropInAction(refillable, false, who);
         }

--- a/FarmAutomation.ItemCollector/Properties/AssemblyInfo.cs
+++ b/FarmAutomation.ItemCollector/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/FarmAutomation.ItemCollector/manifest.json
+++ b/FarmAutomation.ItemCollector/manifest.json
@@ -3,7 +3,7 @@
   "Author": "Oranisagu & Maddy99",
   "Version": {
     "MajorVersion": "0",
-    "MinorVersion": "4",
+    "MinorVersion": "5",
     "PatchVersion": "0",
     "Build": null
   },


### PR DESCRIPTION
ItemCollector crashes for players with Stardew Valley 1.2, which was officially released today. This pull request updates the code for compatibility.

If the changes look fine, can you publish [FarmAutomation.ItemCollector 0.5.zip](https://github.com/maduin81/FarmAutomation_Unofficial/files/953689/FarmAutomation.ItemCollector.0.5.zip) for players to use?